### PR TITLE
Always do Sync GCS step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
         # Go command sets a $DID_RELEASE ENV var to "true" in case a release was produced.
         run: |
           go run ./cmd/release .
-          echo "did_release=${DID_RELEASE}" >> $GITHUB_OUTPUT
+          echo "did_release=$DID_RELEASE" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
   sync:
     needs: release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,15 +31,17 @@ jobs:
         id: release
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        # Go command sets a $DID_RELEASE ENV var to "true" in case a release was produced.
-        run: |
-          go run ./cmd/release .
-          echo "did_release=$DID_RELEASE" >> $GITHUB_OUTPUT
-          cat $GITHUB_OUTPUT
+        run: go run ./cmd/release .
+  # sync job is currently syncing the whole dync directory, it runs
+  # every time, regardless if there was a release or not, or even if the
+  # release job failed. TODO: We can improve efficiency here by doing
+  # two things: (1) only triggering sync job when there's a release
+  # produced from the previous step, and (2) only syncing directories
+  # (or even files) that changed in the rsync invocation.
   sync:
     needs: release
     environment: production
-    if: github.repository == 'bufbuild/modules' && needs.release.outputs.did_release == 'true'
+    if: github.repository == 'bufbuild/modules'
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository code

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: go run ./cmd/release .
-  # sync job is currently syncing the whole dync directory, it runs
+  # sync job is currently syncing the whole sync directory, it runs
   # every time, regardless if there was a release or not, or even if the
   # release job failed. TODO: We can improve efficiency here by doing
   # two things: (1) only triggering sync job when there's a release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,11 @@ jobs:
         id: release
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: go run ./cmd/release . # This sets the "did_release" key=value pair in the GHA output ENV var.
+        # Go command sets a $DID_RELEASE ENV var to "true" in case a release was produced.
+        run: |
+          go run ./cmd/release .
+          echo "did_release=${DID_RELEASE}" >> $GITHUB_OUTPUT
+          cat $GITHUB_OUTPUT
   sync:
     needs: release
     environment: production

--- a/cmd/release/main.go
+++ b/cmd/release/main.go
@@ -34,10 +34,8 @@ import (
 )
 
 const (
-	// ghaEnvVarName is the ENV var that's used by github to hold key=value pairs used as GHA outputs.
-	ghaEnvVarName = "GITHUB_OUTPUT"
-	// didReleaseOutputName is the GHA output for the release action.
-	didReleaseOutputName = "did_release"
+	// didReleaseEnvVar is the ENV var that's read by the GHA to know if a release was done or not.
+	didReleaseEnvVar = "DID_RELEASE"
 )
 
 type command struct {
@@ -143,9 +141,8 @@ func (c *command) run() (retErr error) {
 	if err := createRelease(ctx, githubClient, releaseName, modulesStates); err != nil {
 		return fmt.Errorf("create GitHub release: %w", err)
 	}
-	// Set the Github action output "did_release", so sync GHA job is triggered afterwards.
-	if err := os.Setenv(ghaEnvVarName, fmt.Sprintf("%s=true", didReleaseOutputName)); err != nil {
-		return fmt.Errorf("failed to set %s.%s: %w", ghaEnvVarName, didReleaseOutputName, err)
+	if err := os.Setenv(didReleaseEnvVar, "true"); err != nil {
+		return fmt.Errorf("failed to set %s: %w", didReleaseEnvVar, err)
 	}
 	return nil
 }

--- a/cmd/release/main.go
+++ b/cmd/release/main.go
@@ -33,11 +33,6 @@ import (
 	"go.uber.org/multierr"
 )
 
-const (
-	// didReleaseEnvVar is the ENV var that's read by the GHA to know if a release was done or not.
-	didReleaseEnvVar = "DID_RELEASE"
-)
-
 type command struct {
 	dryRun bool
 }
@@ -140,9 +135,6 @@ func (c *command) run() (retErr error) {
 	}
 	if err := createRelease(ctx, githubClient, releaseName, modulesStates); err != nil {
 		return fmt.Errorf("create GitHub release: %w", err)
-	}
-	if err := os.Setenv(didReleaseEnvVar, "true"); err != nil {
-		return fmt.Errorf("failed to set %s: %w", didReleaseEnvVar, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Not worth the effort too much of skipping non-released steps, if for a minimal change like a single module, and a single blob, we're still syncing the whole sync directory to the bucket. We need a larger effort on optimizing this.