### PR TITLE
Reduce table size in releases body

### DIFF
--- a/cmd/release/main.go
+++ b/cmd/release/main.go
@@ -381,7 +381,8 @@ func writeUpdatedReferencesTable(
 	if fitsInTable {
 		refsToWrite = references // write them all
 	} else {
-		refsToWrite = append(references[0:topRows], references[refCount-bottomRows:]...)
+		refsToWrite = references[0:topRows]
+		refsToWrite = append(refsToWrite, references[refCount-bottomRows:]...)
 	}
 	// write table
 	for i, ref := range refsToWrite {

--- a/cmd/release/main.go
+++ b/cmd/release/main.go
@@ -368,30 +368,34 @@ func writeUpdatedReferencesTable(
 	)); err != nil {
 		return err
 	}
-	// maxRows maximum amount of reference rows in a table
-	const maxRows = 10
-	if refCount <= maxRows { //nolint:nestif
-		for _, ref := range references {
-			if _, err := stringBuilder.WriteString(fmt.Sprintf("| %s | %s |\n", ref.GetName(), ref.GetDigest())); err != nil {
+	const (
+		topRows    = 2
+		bottomRows = 2
+		// maxRows is the maximum amount of reference rows in a table
+		maxRows = topRows + bottomRows + 1 // +1 middle row saying something was skipped
+	)
+	var (
+		refsToWrite []*statev1alpha1.ModuleReference
+		fitsInTable = refCount <= maxRows
+	)
+	if fitsInTable {
+		refsToWrite = references // write them all
+	} else {
+		refsToWrite = append(references[0:topRows], references[refCount-bottomRows:]...)
+	}
+	// write table
+	for i, ref := range refsToWrite {
+		if !fitsInTable && i == topRows {
+			skippedRows := refCount - topRows - bottomRows
+			if _, err := stringBuilder.WriteString(fmt.Sprintf(
+				"| ... %d references skipped ... | ... %d references skipped ... |\n",
+				skippedRows, skippedRows,
+			)); err != nil {
 				return err
 			}
 		}
-	} else {
-		for i, ref := range references {
-			// write only maxRows amount, first 5, last 5
-			if (i < maxRows/2) || (i >= refCount-(maxRows/2)) {
-				if _, err := stringBuilder.WriteString(fmt.Sprintf("| %s | %s |\n", ref.GetName(), ref.GetDigest())); err != nil {
-					return err
-				}
-			}
-			if i == maxRows/2 {
-				if _, err := stringBuilder.WriteString(fmt.Sprintf(
-					"| ... %d references skipped ... | ... %d references skipped ... |\n",
-					refCount-maxRows, refCount-maxRows,
-				)); err != nil {
-					return err
-				}
-			}
+		if _, err := stringBuilder.WriteString(fmt.Sprintf("| %s | %s |\n", ref.GetName(), ref.GetDigest())); err != nil {
+			return err
 		}
 	}
 	if _, err := stringBuilder.WriteString("\n</details>\n"); err != nil {

--- a/cmd/release/main_test.go
+++ b/cmd/release/main_test.go
@@ -357,6 +357,28 @@ func TestWriteReferencesTable(t *testing.T) {
 
 		const (
 			moduleName = "foo/bar"
+			refsCount  = 3
+		)
+		var strBuilder strings.Builder
+		require.NoError(t, writeUpdatedReferencesTable(&strBuilder, moduleName, populateReferences(refsCount)))
+		const want = `
+<details><summary>foo/bar: 3 update(s)</summary>
+
+| Reference | Manifest Digest |
+|---|---|
+| commit000 | digest000 |
+| commit001 | digest001 |
+| commit002 | digest002 |
+
+</details>
+`
+		assert.Equal(t, want, strBuilder.String())
+	})
+	t.Run("rightInTheLimit", func(t *testing.T) {
+		t.Parallel()
+
+		const (
+			moduleName = "foo/bar"
 			refsCount  = 5
 		)
 		var strBuilder strings.Builder
@@ -376,33 +398,29 @@ func TestWriteReferencesTable(t *testing.T) {
 `
 		assert.Equal(t, want, strBuilder.String())
 	})
-	t.Run("rightInTheLimit", func(t *testing.T) {
+	t.Run("oneAfterLimit", func(t *testing.T) {
 		t.Parallel()
 
 		const (
 			moduleName = "foo/bar"
-			refsCount  = 10
+			refsCount  = 6
 		)
 		var strBuilder strings.Builder
 		require.NoError(t, writeUpdatedReferencesTable(&strBuilder, moduleName, populateReferences(refsCount)))
 		const want = `
-<details><summary>foo/bar: 10 update(s)</summary>
+<details><summary>foo/bar: 6 update(s)</summary>
 
 | Reference | Manifest Digest |
 |---|---|
 | commit000 | digest000 |
 | commit001 | digest001 |
-| commit002 | digest002 |
-| commit003 | digest003 |
+| ... 2 references skipped ... | ... 2 references skipped ... |
 | commit004 | digest004 |
 | commit005 | digest005 |
-| commit006 | digest006 |
-| commit007 | digest007 |
-| commit008 | digest008 |
-| commit009 | digest009 |
 
 </details>
 `
+
 		assert.Equal(t, want, strBuilder.String())
 	})
 	t.Run("afterLimit", func(t *testing.T) {
@@ -421,13 +439,7 @@ func TestWriteReferencesTable(t *testing.T) {
 |---|---|
 | commit000 | digest000 |
 | commit001 | digest001 |
-| commit002 | digest002 |
-| commit003 | digest003 |
-| commit004 | digest004 |
-| ... 90 references skipped ... | ... 90 references skipped ... |
-| commit095 | digest095 |
-| commit096 | digest096 |
-| commit097 | digest097 |
+| ... 96 references skipped ... | ... 96 references skipped ... |
 | commit098 | digest098 |
 | commit099 | digest099 |
 

--- a/cmd/release/main_test.go
+++ b/cmd/release/main_test.go
@@ -420,7 +420,6 @@ func TestWriteReferencesTable(t *testing.T) {
 
 </details>
 `
-
 		assert.Equal(t, want, strBuilder.String())
 	})
 	t.Run("afterLimit", func(t *testing.T) {


### PR DESCRIPTION
- Reduce table size to 5 rows per module
- Improve when edge case of only 1 skipped