### PR TITLE
Temporarily remove grpc-gateway license to unblock sync

### DIFF
--- a/modules/static/grpc-ecosystem/grpc-gateway/rsync.incl
+++ b/modules/static/grpc-ecosystem/grpc-gateway/rsync.incl
@@ -1,4 +1,3 @@
-+ LICENSE.txt
 + protoc-gen-openapiv2/
 + protoc-gen-openapiv2/options/
 + protoc-gen-openapiv2/options/*.proto


### PR DESCRIPTION
#85 switched the copied license file for grpc-gateway to the more correct `LICENSE.txt`; however, the BSR is rejecting this file upstream as the currently only allowed name for this file is `LICENSE` (sans extension), causing syncing to fail. Unblocking the sync for now with this patch for a better solution during the work week.