### PR TITLE
Remove googleapis paragraph about v1 and FAQ

### DIFF
--- a/modules/static/googleapis/googleapis/buf.md
+++ b/modules/static/googleapis/googleapis/buf.md
@@ -20,11 +20,6 @@ of unused generated code for the vast majority of developers. To use Google's co
 own module that has a `dep` on `buf.build/googleapis/googleapis` with the specific packages you want
 to use.
 
-Note that this slimming down was a recent breaking change - likely the only breaking change we will
-make before promoting BSR to v1. We taking breaking changes very seriously once launching into v1,
-and we apologize for any disruption as we wrap up the beta. See [the
-FAQ](https://docs.buf.build/faq#googleapis-failure) for more details.
-
 Updates to the [source repository](https://github.com/googleapis/googleapis) are automatically
 synced on a periodic basis, and each BSR commit is tagged with corresponding Git commits.
 


### PR DESCRIPTION
The FAQ link was broken, and we [promoted the BSR out of beta](https://buf.build/blog/plans-pricing-updates/). We haven't dealt with these issues for quite some time. Remove the paragraph. Happy to just update the link and tweak the language in the paragraph, but this felt outdated enough to remove.

(The FAQ link now exists at
https://buf.build/docs/reference/troubleshooting/#googleapis-failure, so we still have something to link to if users ask.)

@unmultimedio, assuming this change will go out in the next sync after it's merged, right?