### PR TITLE
Remove repository GHA input

### DIFF
--- a/.github/workflows/fetch.yaml
+++ b/.github/workflows/fetch.yaml
@@ -17,7 +17,6 @@ jobs:
         with:
           app_id: 295926
           private_key: ${{ secrets.TOKEN_EXCHANGE_GH_APP_PRIVATE_KEY }}
-          repository: ${{ github.repository }}
           permissions: >-
             {"contents": "write", "pull_requests": "write", "members": "read"}
       - name: Checkout repository code


### PR DESCRIPTION
Update the github-app-token step to remove the 'repository' input which no longer exists in v2.