### PR TITLE
Update build dependencies

### DIFF
--- a/.github/workflows/buf.yaml
+++ b/.github/workflows/buf.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: bufbuild/buf-setup-action@v1
         with:
           github_token: ${{ github.token }}
-      - uses: bufbuild/buf-lint-action@v1.0.3
+      - uses: bufbuild/buf-lint-action@v1
         with:
           buf_token: ${{ secrets.BUF_TOKEN }}
   breaking:
@@ -22,6 +22,6 @@ jobs:
       - uses: bufbuild/buf-setup-action@v1
         with:
           github_token: ${{ github.token }}
-      - uses: bufbuild/buf-breaking-action@v1.1.3
+      - uses: bufbuild/buf-breaking-action@v1
         with:
           against: 'https://github.com/bufbuild/modules.git#branch=main'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ concurrency: ci-${{ github.ref }}
 
 jobs:
   ci:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -19,7 +19,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
           cache: true
       - name: Test

--- a/.github/workflows/fetch.yaml
+++ b/.github/workflows/fetch.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   fetch-references:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: github.repository == 'bufbuild/modules'
     steps:
       - name: Generate token
@@ -24,12 +24,12 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
           cache: true
       - name: Install buf cli
         run: |
-          go install github.com/bufbuild/buf/cmd/buf@main
+          go install github.com/bufbuild/buf/cmd/buf@latest
       - name: Fetch references
         run: |
           bash ./scripts/fetch.sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   release:
     if: github.repository == 'bufbuild/modules'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       did_release: ${{ steps.release.outputs.did_release }}
     steps:
@@ -24,7 +24,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
           cache: true
       - name: Create Release
@@ -42,14 +42,14 @@ jobs:
     needs: release
     environment: production
     if: github.repository == 'bufbuild/modules'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository code
         uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
           cache: true
       - name: Auth To GCP

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -24,6 +24,7 @@ linters:
   disable:
     - cyclop            # covered by gocyclo
     - deadcode          # abandoned
+    - depguard          # requires configuration for all non-stdlib deps
     - exhaustruct       # irrelevant for modules
     - exhaustivestruct  # replaced by exhaustruct
     - funlen            # rely on code review to limit function length

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@ MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rules
 MAKEFLAGS += --no-print-directory
 BIN := .tmp/bin
+BUF_VERSION ?= v1.27.0
 COPYRIGHT_YEARS := 2021-2023
+GOLANGCI_LINT_VERSION ?= v1.54.2
 LICENSE_IGNORE := --ignore /testdata/
 # Set to use a different compiler. For example, `GO=go1.18rc1 make test`.
 GO ?= go
@@ -70,16 +72,16 @@ checkgenerate:
 
 $(BIN)/buf: Makefile
 	@mkdir -p $(@D)
-	GOBIN=$(abspath $(@D)) $(GO) install github.com/bufbuild/buf/cmd/buf@v1.13.1
+	GOBIN=$(abspath $(@D)) $(GO) install github.com/bufbuild/buf/cmd/buf@$(BUF_VERSION)
 
 $(BIN)/license-header: Makefile
 	@mkdir -p $(@D)
 	GOBIN=$(abspath $(@D)) $(GO) install \
-		  github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@90fa81df0e9ef86ed505956be1ab1e8ccd49aa52
+		  github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@$(BUF_VERSION)
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.0
+	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 $(BIN)/protoc-gen-go: Makefile go.mod
 	@mkdir -p $(@D)

--- a/proto/buf.gen.yaml
+++ b/proto/buf.gen.yaml
@@ -4,6 +4,7 @@ managed:
   go_package_prefix:
     default: github.com/bufbuild/modules/private/gen
 plugins:
-  - plugin: buf.build/protocolbuffers/go
+  - plugin: go
+    path: .tmp/bin/protoc-gen-go
     out: private/gen/modules
     opt: paths=source_relative


### PR DESCRIPTION
Update go to 1.21.x, buf to 1.27.0, golangci-lint to 1.54.2, and improve the code generation to rely on a specific version of the go plugin and not remote plugins.