### PR TITLE
Remove unnecessary module dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ We currently sync automatically the following modules:
 | gogo/protobuf | https://github.com/gogo/protobuf |  |
 | googleapis/googleapis | https://github.com/googleapis/googleapis |  |
 | googlechrome/lighthouse | https://github.com/GoogleChrome/lighthouse |  |
-| grpc/grpc | https://github.com/grpc/grpc-proto | - envoyproxy/envoy<br>- googleapis/googleapis |
-| grpc-ecosystem/grpc-gateway | https://github.com/grpc-ecosystem/grpc-gateway | - googleapis/googleapis |
+| grpc/grpc | https://github.com/grpc/grpc-proto | - googleapis/googleapis |
+| grpc-ecosystem/grpc-gateway | https://github.com/grpc-ecosystem/grpc-gateway |  |
 | opencensus/opencensus | https://github.com/census-instrumentation/opencensus-proto |  |
 | opentelemetry/opentelemetry | https://github.com/open-telemetry/opentelemetry-proto |  |
 | prometheus/client-model | https://github.com/prometheus/client_model |  |

--- a/modules/static/grpc-ecosystem/grpc-gateway/buf.yaml
+++ b/modules/static/grpc-ecosystem/grpc-gateway/buf.yaml
@@ -1,4 +1,2 @@
 version: v1
 name: buf.build/grpc-ecosystem/grpc-gateway
-deps:
-  - buf.build/googleapis/googleapis

--- a/modules/static/grpc/grpc/buf.yaml
+++ b/modules/static/grpc/grpc/buf.yaml
@@ -1,5 +1,4 @@
 version: v1
 name: buf.build/grpc/grpc
 deps:
-  - buf.build/envoyproxy/envoy
   - buf.build/googleapis/googleapis


### PR DESCRIPTION
- https://buf.build/grpc/grpc/deps/main
- https://buf.build/grpc-ecosystem/grpc-gateway/deps/main

Used `buf export` to pull modules locally and confirmed with `buf build` that each module builds as expected with new buf.yaml configs