### PR TITLE
Optimize modules release time

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,4 +60,4 @@ jobs:
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b
       - name: Upload To Release Bucket
-        run: gsutil rsync -r modules/sync gs://buf-modules
+        run: gsutil -m rsync -c -r modules/sync gs://buf-modules


### PR DESCRIPTION
We should run with `-m` option to enable parallel uploads. Additionally, we should run with either `-c` or `-i` instead of the default (which compares modification time). Since files are sync'd from a actions/checkout git clone, all of the files mtimes are set to the time of checkout, so the default behavior will be to copy every file every time.