### PR TITLE
Reenable fetching references for `cncf/xds` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ We currently sync automatically the following modules:
 | bufbuild/confluent | https://github.com/bufbuild/confluent-proto |  |
 | bufbuild/protovalidate | https://github.com/bufbuild/protovalidate |  |
 | bufbuild/protovalidate-testing | https://github.com/bufbuild/protovalidate | - bufbuild/protovalidate |
-| cncf/xds | https://github.com/cncf/xds | - envoyproxy/protoc-gen-validate<br>- googleapis/googleapis |
+| cncf/xds | https://github.com/cncf/xds | - envoyproxy/protoc-gen-validate<br>- google/cel-spec<br>- googleapis/googleapis |
 | envoyproxy/envoy | https://github.com/envoyproxy/envoy | - cncf/xds<br>- envoyproxy/protoc-gen-validate<br>- googleapis/googleapis<br>- opencensus/opencensus<br>- opentelemetry/opentelemetry<br>- prometheus/client-model |
 | envoyproxy/protoc-gen-validate | https://github.com/envoyproxy/protoc-gen-validate |  |
 | gogo/protobuf | https://github.com/gogo/protobuf |  |

--- a/modules/static/cncf/xds/buf.yaml
+++ b/modules/static/cncf/xds/buf.yaml
@@ -2,4 +2,5 @@ version: v1
 name: buf.build/cncf/xds
 deps:
   - buf.build/envoyproxy/protoc-gen-validate
+  - buf.build/google/cel-spec
   - buf.build/googleapis/googleapis

--- a/scripts/fetch.sh
+++ b/scripts/fetch.sh
@@ -179,8 +179,7 @@ trap cleanup EXIT
 sync_references commits bufbuild confluent https://github.com/bufbuild/confluent-proto
 sync_references releases bufbuild protovalidate https://github.com/bufbuild/protovalidate proto/protovalidate
 sync_references releases bufbuild protovalidate-testing https://github.com/bufbuild/protovalidate proto/protovalidate-testing
-# TODO: reenable once the new dep is also synced https://github.com/bufbuild/modules/issues/339
-# sync_references commits cncf xds https://github.com/cncf/xds
+sync_references commits cncf xds https://github.com/cncf/xds
 sync_references commits envoyproxy envoy https://github.com/envoyproxy/envoy api
 sync_references commits envoyproxy protoc-gen-validate https://github.com/envoyproxy/protoc-gen-validate
 sync_references commits gogo protobuf https://github.com/gogo/protobuf


### PR DESCRIPTION
This one works now because the new dependency https://buf.build/google/cel-spec is already being synced.