### PR TITLE
Open a single PR if changes are found

### DIFF
--- a/.github/workflows/fetch.yaml
+++ b/.github/workflows/fetch.yaml
@@ -42,7 +42,7 @@ jobs:
         with:
           add-paths: ./modules/sync/**
           commit-message: "Detected new managed modules references"
-          branch: fetch-versions-${{ github.run_id }}
+          branch: fetch-modules
           delete-branch: true
           title: "Found new managed modules references"
           body: "New managed modules references found. Please review."


### PR DESCRIPTION
Currently, the fetch.yaml workflow will create a unique PR each time it detects changes. This means that if we don't merge an update one day, we'll get duplicate PRs (of which only one can be merged without merge conflicts on the other).

Update the workflow to use a consistent branch name to avoid this (there will only ever be a single PR open at a time).