### PR TITLE
Skip opencensus and opentelemetry to unblock fetch references job

### DIFF
--- a/scripts/fetch.sh
+++ b/scripts/fetch.sh
@@ -210,7 +210,8 @@ sync_references commits googleapis googleapis https://github.com/googleapis/goog
 sync_references commits googlechrome lighthouse https://github.com/GoogleChrome/lighthouse proto
 sync_references commits grpc grpc https://github.com/grpc/grpc-proto
 sync_references commits grpc-ecosystem grpc-gateway https://github.com/grpc-ecosystem/grpc-gateway
-sync_references commits opencensus opencensus https://github.com/census-instrumentation/opencensus-proto src
+# TODO: re-enable once unblocked
+# sync_references commits opencensus opencensus https://github.com/census-instrumentation/opencensus-proto src
 sync_references commits opentelemetry opentelemetry https://github.com/open-telemetry/opentelemetry-proto
 sync_references commits prometheus client-model https://github.com/prometheus/client_model
 sync_references releases protocolbuffers wellknowntypes https://github.com/protocolbuffers/protobuf src

--- a/scripts/fetch.sh
+++ b/scripts/fetch.sh
@@ -212,7 +212,7 @@ sync_references commits grpc grpc https://github.com/grpc/grpc-proto
 sync_references commits grpc-ecosystem grpc-gateway https://github.com/grpc-ecosystem/grpc-gateway
 # TODO: re-enable once unblocked
 # sync_references commits opencensus opencensus https://github.com/census-instrumentation/opencensus-proto src
-sync_references commits opentelemetry opentelemetry https://github.com/open-telemetry/opentelemetry-proto
+# sync_references commits opentelemetry opentelemetry https://github.com/open-telemetry/opentelemetry-proto
 sync_references commits prometheus client-model https://github.com/prometheus/client_model
 sync_references releases protocolbuffers wellknowntypes https://github.com/protocolbuffers/protobuf src
 


### PR DESCRIPTION
In the past days [no new references have been fetched](https://github.com/bufbuild/modules/actions/workflows/fetch.yaml) because of `opencensus/opencensus` failing to fetch because of an error in a proto file.

The failure is:

```
processing reference opentelemetry/opentelemetry:acc967d52c8485f0ae3338f2c311ee91a100b70c
opentelemetry/proto/trace/v1/trace.proto:289:32:message opentelemetry.proto.trace.v1.Span: fields flags and parent_span_is_remote both have the same tag 16
```

The offending commit is this one: https://github.com/open-telemetry/opentelemetry-proto/commit/acc967d52c8485f0ae3338f2c311ee91a100b70c#diff-5c407ac9c675a60170f94ab620f5329f25e5388d6790864b7799abce66f79332 (which is reusing the same tag number)

Skipping both opencensus and opentelemetry, since the former is now being forwarded to the latter.