### PR TITLE
Create a GH issue on workflow failure

### DIFF
--- a/.github/automatic-workflow-issue-template.md
+++ b/.github/automatic-workflow-issue-template.md
@@ -1,0 +1,8 @@
+---
+title: Unexpected {{ workflow }} failure
+assignees: unmultimedio, pkwarren
+labels: bug
+---
+
+The automatic {{ workflow }} workflow failed, please investigate:
+{{ env.GITHUB_SERVER_URL }}/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}/attempts/{{ env.GITHUB_RUN_ATTEMPT }}

--- a/.github/workflows/fetch.yaml
+++ b/.github/workflows/fetch.yaml
@@ -5,7 +5,9 @@ on:
     # At 7:00 EST (12:00 UTC) on every day-of-week from Monday through Friday. https://crontab.guru/#0_12_*_*_1-5
     - cron: "0 12 * * 1-5"
   workflow_dispatch:
-
+permissions:
+  contents: read
+  issues: write
 jobs:
   fetch-references:
     runs-on: ubuntu-latest
@@ -48,3 +50,15 @@ jobs:
           body: "New managed modules references found. Please review."
           team-reviewers: bufbuild/bsr-team
           token: ${{ steps.generate_token.outputs.token }}
+      - uses: dblock/create-a-github-issue@866beb009af3db457e82ca98efe474969a5ebce8
+        if: failure()
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_SERVER_URL: ${ github.server_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
+        with:
+          filename: .github/automatic-workflow-issue-template.md
+          update_existing: true
+          search_existing: open

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  issues: write
   packages: read
 
 jobs:
@@ -32,6 +33,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: go run ./cmd/release .
+      - uses: dblock/create-a-github-issue@866beb009af3db457e82ca98efe474969a5ebce8
+        if: failure()
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_SERVER_URL: ${ github.server_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
+        with:
+          filename: .github/automatic-workflow-issue-template.md
+          update_existing: true
+          search_existing: open
   # sync job is currently syncing the whole sync directory, it runs
   # every time, regardless if there was a release or not, or even if the
   # release job failed. TODO: We can improve efficiency here by doing
@@ -61,3 +74,15 @@ jobs:
         uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200
       - name: Upload To Release Bucket
         run: gsutil -m rsync -c -r modules/sync gs://buf-modules
+      - uses: dblock/create-a-github-issue@866beb009af3db457e82ca98efe474969a5ebce8
+        if: failure()
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_SERVER_URL: ${ github.server_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
+        with:
+          filename: .github/automatic-workflow-issue-template.md
+          update_existing: true
+          search_existing: open


### PR DESCRIPTION
If there are any issues in the automated workflows (fetch.yaml and release.yaml), open a GH issue to track the problem.