### PR TITLE
Only login if BUF_TOKEN is found

### DIFF
--- a/scripts/fetch.sh
+++ b/scripts/fetch.sh
@@ -2,8 +2,8 @@
 
 set -eo pipefail
 
-if [[ -n "${BUF_TOKEN}" ]]; then
-  echo "${BUF_TOKEN}" | buf registry login --debug --token-stdin --username "${BUF_USER}"
+if [[ -n "${BUF_TOKEN}" && -n "${BUF_USER}" ]]; then
+  echo "${BUF_TOKEN}" | buf registry login --token-stdin --username "${BUF_USER}"
 fi
 
 repo_root="$(cd "$(dirname "${0}")/.." && pwd)"

--- a/scripts/fetch.sh
+++ b/scripts/fetch.sh
@@ -2,7 +2,9 @@
 
 set -eo pipefail
 
-echo "${BUF_TOKEN}" | buf registry login --debug --token-stdin --username "${BUF_USER}"
+if [[ -n "${BUF_TOKEN}" ]]; then
+  echo "${BUF_TOKEN}" | buf registry login --debug --token-stdin --username "${BUF_USER}"
+fi
 
 repo_root="$(cd "$(dirname "${0}")/.." && pwd)"
 all_mods_sync_path="${repo_root}/modules/sync"


### PR DESCRIPTION
Update the fetch.sh script to be more easily called locally by only logging in to the BSR if the BSR_TOKEN environment variable is set.