### PR TITLE
Stop pushing git metadata in `buf-ci`

### DIFF
--- a/.github/workflows/buf-ci.yaml
+++ b/.github/workflows/buf-ci.yaml
@@ -26,4 +26,5 @@ jobs:
           username: ${{ secrets.BUF_USER }}
           token: ${{ secrets.BUF_TOKEN }}
           push_create_visibility: public
+          push_git_metadata: false
           version: 1.34.0


### PR DESCRIPTION
Allow squashing for commits here: https://buf.build/bufbuild/managed-modules/commits