### PR TITLE
Update fetch template

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+modules/sync/** linguist-generated=true

--- a/.github/workflows/fetch.yaml
+++ b/.github/workflows/fetch.yaml
@@ -51,7 +51,6 @@ jobs:
           body: |
             New managed modules references found. Please review.
             
-            - [ ] `envoyproxy/envoy` has updates, I have checked https://github.com/bufbuild/modules/issues/591
             - [ ] `googlecloudplatform/bq-schema-api` has updates, I have checked https://github.com/bufbuild/modules/issues/592
           team-reviewers: bufbuild/bsr-team
           token: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
Update fetch template to indicate envoyproxy/envoy is now migrated to releases. Mark all files under modules/sync as generated.