### PR TITLE
Exclude `state.json` from linguist generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 modules/sync/** linguist-generated=true
+modules/sync/**/state.json linguist-generated=false


### PR DESCRIPTION
So fetch module PRs show `state.json` by default. Those changes are just git shas and digests.