### PR TITLE
Pause syncing `gofeatures` module

### DIFF
--- a/scripts/fetch.sh
+++ b/scripts/fetch.sh
@@ -228,7 +228,8 @@ sync_references releases grpc-ecosystem grpc-gateway https://github.com/grpc-eco
 sync_references releases opencensus opencensus https://github.com/census-instrumentation/opencensus-proto src
 sync_references releases opentelemetry opentelemetry https://github.com/open-telemetry/opentelemetry-proto
 sync_references releases prometheus client-model https://github.com/prometheus/client_model
-sync_references releases protocolbuffers gofeatures https://github.com/protocolbuffers/protobuf-go src
+# TODO: remove after it finishes syncing its README's deprecation notice in existing BSRs.
+# sync_references releases protocolbuffers gofeatures https://github.com/protocolbuffers/protobuf-go src
 sync_references releases protocolbuffers wellknowntypes https://github.com/protocolbuffers/protobuf src
 
 popd > /dev/null


### PR DESCRIPTION
We cannot remove all its references yet, we need to wait for the new README (with the deprecation notice) to be synced to existing BSRs.

Related to #808