### PR TITLE
Update `go_features.proto` location in WKT

### DIFF
--- a/modules/static/protocolbuffers/wellknowntypes/pre-sync.sh
+++ b/modules/static/protocolbuffers/wellknowntypes/pre-sync.sh
@@ -1,2 +1,2 @@
 cp ../java/core/src/main/resources/google/protobuf/java_features.proto google/protobuf
-cp ../go/go_features.proto google/protobuf
+cp ../go/google/protobuf/go_features.proto google/protobuf


### PR DESCRIPTION
WKT syncing did not find `go_features.proto` file:

```
processing reference protocolbuffers/wellknowntypes:v29.3
cp: cannot stat '../go/go_features.proto': No such file or directory
```

They moved it in [this commit](https://github.com/protocolbuffers/protobuf/commit/2887da22a1284a8f033efe67e02eb5f0fde4923f):

```
‎go/go_features.proto -> ‎go/google/protobuf/go_features.proto
```

Fixes #824