### PR TITLE
Move from gsutil to gcloud storage

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,7 +81,7 @@ jobs:
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
       - name: Upload To Release Bucket
-        run: gsutil -m rsync -c -r modules/sync gs://buf-modules
+        run: gcloud storage rsync --checksums-only --recursive modules/sync gs://buf-modules
       - uses: dblock/create-a-github-issue@a25e69ccb88998dc267170a0dbde8ef8ac3a491c # v3.4.0
         if: failure()
         env:


### PR DESCRIPTION
The gsutil command is deprecated. Switch to the replacement 'gcloud storage' command.